### PR TITLE
add self host

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,8 +3,8 @@ on: [pull_request]
 jobs:
   linter:
     name: Run Linter Check
-    runs-on: ubuntu-18.04
-    timeout-minutes: 3
+    runs-on: self-hosted
+    timeout-minutes: 10
     steps:
     - name: Check out the code
       uses: actions/checkout@v2

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -3,6 +3,6 @@ on: pull_request
 
 jobs:
   add-reviews:
-    runs-on: ubuntu-18.04
+    runs-on: self-hosted
     steps:
       - uses: kentaro-m/auto-assign-action@v1.1.2


### PR DESCRIPTION
- change CI/CD node from github vm to team machine
- extend lint timeout to 10min

팀 내 논의 결과 팀환경 4번 노드에서 provisioner CI/CD를 수행하기로 했습니다. 현재 4번 노드에 service로 action hooker를 작동시켰고, 본 PR의 lint 작업이 정상 수행됐음을 확인 가능합니다.

Signed-off-by: Taeuk Kim <taeuk_kim@tmax.co.kr>