### PR TITLE
Add skip-ci to linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,8 +2,12 @@ name: Pull Request Linter Check
 on: [pull_request]
 jobs:
   linter:
+    if: "! contains(github.event.pull_request.body, '[skip-ci]')"
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
     name: Run Linter Check
-    runs-on: self-hosted
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
     - name: Check out the code


### PR DESCRIPTION
- add [skip-ci] to bypass linting
- modify lint host from self-host(node3) to github vm

[skip-ci]

Signed-off-by: Taeuk Kim <taeuk_kim@tmax.co.kr>